### PR TITLE
Remove class 'activeref' when references are not active

### DIFF
--- a/scribe.js
+++ b/scribe.js
@@ -467,6 +467,9 @@ if (!mw.messages.exists('ve-scribe-dialog-title')) {
             ScribeDialog.prototype.getActionProcess = function (action) {
                 var dialog, sectionNumber, activeSectionTitle;
 
+                // removing the class which enalbes a reference to be selected by defualt
+                $('.mw-scribe-ref-box').removeClass('activeref');
+
                 // Activate on click event for the reference section next/prev
                 activeOnClickEventForNext('.next');
                 activeOnClickEventForPrev('.prev');


### PR DESCRIPTION
- Removed the 'activeref' class when the there is an action on the dialog
  which will be activated once the next and previous are clicked

Bug: [T240464](https://phabricator.wikimedia.org/T240464)